### PR TITLE
Add support for non-default SPI class

### DIFF
--- a/PN5180.cpp
+++ b/PN5180.cpp
@@ -39,11 +39,12 @@
 
 uint8_t PN5180::readBuffer[508];
 
-PN5180::PN5180(uint8_t SSpin, uint8_t BUSYpin, uint8_t RSTpin) {
-  PN5180_NSS = SSpin;
-  PN5180_BUSY = BUSYpin;
-  PN5180_RST = RSTpin;
-
+PN5180::PN5180(uint8_t SSpin, uint8_t BUSYpin, uint8_t RSTpin, SPIClass& spi) :
+  PN5180_NSS(SSpin),
+  PN5180_BUSY(BUSYpin),
+  PN5180_RST(RSTpin),
+  PN5180_SPI(spi)
+{
   /*
    * 11.4.1 Physical Host Interface
    * The interface of the PN5180 to a host microcontroller is based on a SPI interface,
@@ -63,7 +64,7 @@ void PN5180::begin() {
   digitalWrite(PN5180_NSS, HIGH); // disable
   digitalWrite(PN5180_RST, HIGH); // no reset
 
-  SPI.begin();
+  PN5180_SPI.begin();
   PN5180DEBUG(F("SPI pinout: "));
   PN5180DEBUG(F("SS=")); PN5180DEBUG(SS);
   PN5180DEBUG(F(", MOSI=")); PN5180DEBUG(MOSI);
@@ -74,7 +75,7 @@ void PN5180::begin() {
 
 void PN5180::end() {
   digitalWrite(PN5180_NSS, HIGH); // disable
-  SPI.end();
+  PN5180_SPI.end();
 }
 
 /*
@@ -102,9 +103,9 @@ bool PN5180::writeRegister(uint8_t reg, uint32_t value) {
    */
   uint8_t buf[6] = { PN5180_WRITE_REGISTER, reg, p[0], p[1], p[2], p[3] };
 
-  SPI.beginTransaction(SPI_SETTINGS);
+  PN5180_SPI.beginTransaction(SPI_SETTINGS);
   transceiveCommand(buf, 6);
-  SPI.endTransaction();
+  PN5180_SPI.endTransaction();
 
   return true;
 }
@@ -132,9 +133,9 @@ bool PN5180::writeRegisterWithOrMask(uint8_t reg, uint32_t mask) {
 
   uint8_t buf[6] = { PN5180_WRITE_REGISTER_OR_MASK, reg, p[0], p[1], p[2], p[3] };
 
-  SPI.beginTransaction(SPI_SETTINGS);
+  PN5180_SPI.beginTransaction(SPI_SETTINGS);
   transceiveCommand(buf, 6);
-  SPI.endTransaction();
+  PN5180_SPI.endTransaction();
 
   return true;
 }
@@ -162,9 +163,9 @@ bool PN5180::writeRegisterWithAndMask(uint8_t reg, uint32_t mask) {
 
   uint8_t buf[6] = { PN5180_WRITE_REGISTER_AND_MASK, reg, p[0], p[1], p[2], p[3] };
 
-  SPI.beginTransaction(SPI_SETTINGS);
+  PN5180_SPI.beginTransaction(SPI_SETTINGS);
   transceiveCommand(buf, 6);
-  SPI.endTransaction();
+  PN5180_SPI.endTransaction();
 
   return true;
 }
@@ -183,9 +184,9 @@ bool PN5180::readRegister(uint8_t reg, uint32_t *value) {
 
   uint8_t cmd[2] = { PN5180_READ_REGISTER, reg };
 
-  SPI.beginTransaction(SPI_SETTINGS);
+  PN5180_SPI.beginTransaction(SPI_SETTINGS);
   transceiveCommand(cmd, 2, (uint8_t*)value, 4);
-  SPI.endTransaction();
+  PN5180_SPI.endTransaction();
 
   PN5180DEBUG(F("Register value=0x"));
   PN5180DEBUG(formatHex(*value));
@@ -202,9 +203,9 @@ bool PN5180::writeEEprom(uint8_t addr, uint8_t *buffer, uint8_t len) {
 	cmd[0] = PN5180_WRITE_EEPROM;
 	cmd[1] = addr;
 	for (int i = 0; i < len; i++) cmd[2 + i] = buffer[i];
-	SPI.beginTransaction(SPI_SETTINGS);
+	PN5180_SPI.beginTransaction(SPI_SETTINGS);
 	transceiveCommand(cmd, len + 2);
-	SPI.endTransaction();
+	PN5180_SPI.endTransaction();
 	return true;
 }
 
@@ -233,9 +234,9 @@ bool PN5180::readEEprom(uint8_t addr, uint8_t *buffer, int len) {
 
   uint8_t cmd[3] = { PN5180_READ_EEPROM, addr, uint8_t(len) };
 
-  SPI.beginTransaction(SPI_SETTINGS);
+  PN5180_SPI.beginTransaction(SPI_SETTINGS);
   transceiveCommand(cmd, 3, buffer, len);
-  SPI.endTransaction();
+  PN5180_SPI.endTransaction();
 
 #ifdef DEBUG
   PN5180DEBUG(F("EEPROM values: "));
@@ -306,9 +307,9 @@ bool PN5180::sendData(uint8_t *data, int len, uint8_t validBits) {
     return false;
   }
 
-  SPI.beginTransaction(SPI_SETTINGS);
+  PN5180_SPI.beginTransaction(SPI_SETTINGS);
   bool success = transceiveCommand(buffer, len+2);
-  SPI.endTransaction();
+  PN5180_SPI.endTransaction();
 
   return success;
 }
@@ -335,9 +336,9 @@ uint8_t * PN5180::readData(int len) {
 
   uint8_t cmd[2] = { PN5180_READ_DATA, 0x00 };
 
-  SPI.beginTransaction(SPI_SETTINGS);
+  PN5180_SPI.beginTransaction(SPI_SETTINGS);
   transceiveCommand(cmd, 2, readBuffer, len);
-  SPI.endTransaction();
+  PN5180_SPI.endTransaction();
 
 #ifdef DEBUG
   PN5180DEBUG(F("Data read: "));
@@ -356,9 +357,9 @@ bool PN5180::readData(uint8_t len, uint8_t *buffer) {
 		return false;
 	}
 	uint8_t cmd[2] = { PN5180_READ_DATA, 0x00 };
-	SPI.beginTransaction(SPI_SETTINGS);
+	PN5180_SPI.beginTransaction(SPI_SETTINGS);
 	bool success = transceiveCommand(cmd, 2, buffer, len);
-	SPI.endTransaction();
+	PN5180_SPI.endTransaction();
 	return success;
 }
 
@@ -430,9 +431,9 @@ bool PN5180::switchToLPCD(uint16_t wakeupCounterInMs) {
   writeRegister(IRQ_ENABLE, LPCD_IRQ_STAT | GENERAL_ERROR_IRQ_STAT);  
   // switch mode to LPCD 
   uint8_t cmd[4] = { PN5180_SWITCH_MODE, 0x01, (uint8_t)(wakeupCounterInMs & 0xFF), (uint8_t)((wakeupCounterInMs >> 8U) & 0xFF) };
-  SPI.beginTransaction(SPI_SETTINGS);
+  PN5180_SPI.beginTransaction(SPI_SETTINGS);
   bool success = transceiveCommand(cmd, sizeof(cmd));
-  SPI.endTransaction();
+  PN5180_SPI.endTransaction();
   return success;
 }
 
@@ -463,9 +464,9 @@ bool PN5180::loadRFConfig(uint8_t txConf, uint8_t rxConf) {
 
   uint8_t cmd[3] = { PN5180_LOAD_RF_CONFIG, txConf, rxConf };
 
-  SPI.beginTransaction(SPI_SETTINGS);
+  PN5180_SPI.beginTransaction(SPI_SETTINGS);
   transceiveCommand(cmd, 3);
-  SPI.endTransaction();
+  PN5180_SPI.endTransaction();
 
   return true;
 }
@@ -480,9 +481,9 @@ bool PN5180::setRF_on() {
 
   uint8_t cmd[2] = { PN5180_RF_ON, 0x00 };
 
-  SPI.beginTransaction(SPI_SETTINGS);
+  PN5180_SPI.beginTransaction(SPI_SETTINGS);
   transceiveCommand(cmd, 2);
-  SPI.endTransaction();
+  PN5180_SPI.endTransaction();
 
   unsigned long startedWaiting = millis();
   while (0 == (TX_RFON_IRQ_STAT & getIRQStatus())) {   // wait for RF field to set up (max 500ms)
@@ -506,9 +507,9 @@ bool PN5180::setRF_off() {
 
   uint8_t cmd[2] { PN5180_RF_OFF, 0x00 };
 
-  SPI.beginTransaction(SPI_SETTINGS);
+  PN5180_SPI.beginTransaction(SPI_SETTINGS);
   transceiveCommand(cmd, 2);
-  SPI.endTransaction();
+  PN5180_SPI.endTransaction();
 
   unsigned long startedWaiting = millis();
   while (0 == (TX_RFOFF_IRQ_STAT & getIRQStatus())) {   // wait for RF field to shut down
@@ -581,7 +582,7 @@ bool PN5180::transceiveCommand(uint8_t *sendBuffer, size_t sendBufferLen, uint8_
   digitalWrite(PN5180_NSS, LOW); delay(1);
   // 2.
   for (uint8_t i=0; i<sendBufferLen; i++) {
-    SPI.transfer(sendBuffer[i]);
+    PN5180_SPI.transfer(sendBuffer[i]);
   }
   // 3.
   startedWaiting = millis();
@@ -611,7 +612,7 @@ bool PN5180::transceiveCommand(uint8_t *sendBuffer, size_t sendBufferLen, uint8_
   digitalWrite(PN5180_NSS, LOW); 
   // 2.
   for (uint8_t i=0; i<recvBufferLen; i++) {
-    recvBuffer[i] = SPI.transfer(0xff);
+    recvBuffer[i] = PN5180_SPI.transfer(0xff);
   }
   // 3.
   startedWaiting = millis(); delay(1);

--- a/PN5180.h
+++ b/PN5180.h
@@ -76,12 +76,13 @@ private:
   uint8_t PN5180_NSS;   // active low
   uint8_t PN5180_BUSY;
   uint8_t PN5180_RST;
+  SPIClass& PN5180_SPI;
 
   SPISettings SPI_SETTINGS;
   static uint8_t readBuffer[508];
 
 public:
-  PN5180(uint8_t SSpin, uint8_t BUSYpin, uint8_t RSTpin);
+  PN5180(uint8_t SSpin, uint8_t BUSYpin, uint8_t RSTpin, SPIClass& spi=SPI);
 
   void begin();
   void end();

--- a/PN5180ISO14443.cpp
+++ b/PN5180ISO14443.cpp
@@ -23,8 +23,8 @@
 #include <PN5180.h>
 #include "Debug.h"
 
-PN5180ISO14443::PN5180ISO14443(uint8_t SSpin, uint8_t BUSYpin, uint8_t RSTpin) 
-              : PN5180(SSpin, BUSYpin, RSTpin) {
+PN5180ISO14443::PN5180ISO14443(uint8_t SSpin, uint8_t BUSYpin, uint8_t RSTpin, SPIClass& spi) 
+              : PN5180(SSpin, BUSYpin, RSTpin, spi) {
 }
 
 bool PN5180ISO14443::setupRF() {

--- a/PN5180ISO14443.h
+++ b/PN5180ISO14443.h
@@ -25,7 +25,7 @@
 class PN5180ISO14443 : public PN5180 {
 
 public:
-  PN5180ISO14443(uint8_t SSpin, uint8_t BUSYpin, uint8_t RSTpin);
+  PN5180ISO14443(uint8_t SSpin, uint8_t BUSYpin, uint8_t RSTpin, SPIClass& spi=SPI);
   
 private:
   uint16_t rxBytesReceived();

--- a/PN5180ISO15693.cpp
+++ b/PN5180ISO15693.cpp
@@ -22,8 +22,8 @@
 #include "PN5180ISO15693.h"
 #include "Debug.h"
 
-PN5180ISO15693::PN5180ISO15693(uint8_t SSpin, uint8_t BUSYpin, uint8_t RSTpin) 
-              : PN5180(SSpin, BUSYpin, RSTpin) {
+PN5180ISO15693::PN5180ISO15693(uint8_t SSpin, uint8_t BUSYpin, uint8_t RSTpin, SPIClass& spi) 
+              : PN5180(SSpin, BUSYpin, RSTpin, spi) {
 }
 
 /*

--- a/PN5180ISO15693.h
+++ b/PN5180ISO15693.h
@@ -39,7 +39,7 @@ enum ISO15693ErrorCode {
 class PN5180ISO15693 : public PN5180 {
 
 public:
-  PN5180ISO15693(uint8_t SSpin, uint8_t BUSYpin, uint8_t RSTpin);
+  PN5180ISO15693(uint8_t SSpin, uint8_t BUSYpin, uint8_t RSTpin, SPIClass& spi=SPI);
   
 private:
   ISO15693ErrorCode issueISO15693Command(uint8_t *cmd, uint8_t cmdLen, uint8_t **resultPtr);


### PR DESCRIPTION
This implementation looks quite similar to @tyllmoritz previous changes, but it doesn't copy the SPI class. Instead, the class member is now a reference, which is initialized in the constructor.

The SPIClass parameter of the constructor has "SPI" as the default. This makes sure to not break non-adapted code.

If you have any comments or concerns, please let me know!