### PR TITLE
added readMultipleBlock, fixed bugs

### DIFF
--- a/Debug.cpp
+++ b/Debug.cpp
@@ -19,7 +19,7 @@
 #include <inttypes.h>
 #include "Debug.h"
 
-#ifdef DEBUG
+//#ifdef DEBUG
 
 static const char hexChar[] = "0123456789ABCDEF";
 static char hexBuffer[9];
@@ -49,4 +49,4 @@ char * formatHex(uint32_t val) {
   return hexBuffer;
 }
 
-#endif
+//#endif

--- a/PN5180.h
+++ b/PN5180.h
@@ -129,7 +129,7 @@ public:
 public:
   void reset();
 
-  uint8_t commandTimeout = 50;
+  uint8_t commandTimeout = 500;
   uint32_t getIRQStatus();
   bool clearIRQStatus(uint32_t irqMask);
 

--- a/PN5180ISO15693.cpp
+++ b/PN5180ISO15693.cpp
@@ -70,6 +70,107 @@ ISO15693ErrorCode PN5180ISO15693::getInventory(uint8_t *uid) {
 }
 
 /*
+ * Inventory with flag set for 16 time slots, code=01
+ * https://www.nxp.com.cn/docs/en/application-note/AN12650.pdf
+ * Request format: SOF, Req.Flags, Inventory, AFI (opt.), Mask len, Mask value, CRC16, EOF
+ * Response format: SOF, Resp.Flags, DSFID, UID, CRC16, EOF
+ *
+ */
+ISO15693ErrorCode PN5180ISO15693::getInventoryMultiple(uint8_t *uid, uint8_t maxTags, uint8_t *numCard) {
+  ESP_LOGD(TAG,"getInventory: Get Inventory...");
+  uint8_t collision[maxTags];
+  *numCard = 0;
+  uint8_t numCol = 0;
+  inventoryPoll(uid, maxTags, numCard, &numCol, collision);
+  PN5180DEBUG("Number of collisions=");
+  PN5180DEBUG(numCol)
+  PN5180DEBUG("\n");
+
+  while(numCol){                                                 // 5+ Continue until no collisions detected
+#ifdef DEBUG
+    printf("inventoryPoll: Polling with mask=0x%X\n", collision[0]);
+#endif
+    inventoryPoll(uid, maxTags, numCard, &numCol, collision);
+    numCol--;
+    for(int i=0; i<numCol; i++){
+      collision[i] = collision[i+1];
+    }
+  }
+  return ISO15693_EC_OK;
+}
+
+ISO15693ErrorCode PN5180ISO15693::inventoryPoll(uint8_t *uid, uint8_t maxTags, uint8_t *numCard, uint8_t *numCol, uint8_t *collision){
+  uint8_t maskLen = 0;
+  if(*numCol > 0){
+    uint32_t mask = collision[0];
+    do{
+      mask >>= 4L;
+      maskLen++;
+    }while(mask > 0);
+  } 
+  uint8_t *readBuffer;
+  uint8_t *p = &collision[0];
+  //                      Flags,  CMD,
+  uint8_t inventory[7] = { 0x06, 0x01, maskLen*4, p[0], p[1], p[2], p[3] };
+  //                         |\- inventory flag + high data rate
+  //                         \-- 16 slots: upto 16 cards, no AFI field present
+  uint8_t cmdLen = 3 + (maskLen/2) + (maskLen%2);
+#ifdef DEBUG
+  printf("mask=%d, maskLen=%d, cmdLen=%d\n", collision[0], maskLen, cmdLen);
+#endif
+  clearIRQStatus(0x000FFFFF);                                  // 3. Clear all IRQ_STATUS flags
+  sendData(inventory, cmdLen, 0);                              // 4. 5. 6. Idle/StopCom Command, Transceive Command, Inventory command
+  
+  for(int slot=0; slot<16; slot++){                                   // 7. Loop to check 16 time slots for data
+    uint32_t rxStatus;
+    uint32_t irqStatus = getIRQStatus();
+    readRegister(RX_STATUS, &rxStatus);
+    uint16_t len = (uint16_t)(rxStatus & 0x000001ff);
+    if((rxStatus >> 18) & 0x01 && *numCol < maxTags){                  // 7+ Determine if a collision occurred
+      if(maskLen > 0) collision[*numCol++] = collision[0] | (slot << (maskLen * 2));
+      else collision[*numCol++] = slot << (maskLen * 2);     // Yes, store position of collision
+#ifdef DEBUG
+      printf("Collision detected for UIDs matching %X starting at LSB", collision[*numCol-1]);
+#endif
+    }
+    else if(!(irqStatus & RX_IRQ_STAT) && !len){               // 8. Check if a card has responded
+      PN5180DEBUG("getInventoryMultiple: No card in this time slot. State=");
+      PN5180DEBUG(irqStatus);
+      PN5180DEBUG("\n");
+    }
+    else{
+#ifdef DEBUG
+      printf("slot=%d, irqStatus: %ld, RX_STATUS: %ld, Response length=%d", slot, irqStatus, rxStatus, len);
+#endif
+      readBuffer = readData(len);                              // 9. Read reception buffer
+      if(0L == readBuffer){
+        PN5180DEBUG("getInventoryMultiple: ERROR in readData!");
+        return ISO15693_EC_UNKNOWN_ERROR;
+      }
+
+      // Record raw UID data                                          // 10. Record all data to Inventory struct
+      for (int i=0; i<8; i++) {
+        uid[*numCard*8 + i] = readBuffer[2+i];
+      }
+
+#ifdef DEBUG
+      printf("getInventory: Response flags: 0x%X, Data Storage Format ID: 0x%X\n", readBuffer[0], readBuffer[1]);
+#endif
+      *numCard++;
+    }
+    
+    if(slot+1 < 16){ // If we have more cards to poll for...
+      writeRegisterWithAndMask(TX_CONFIG, 0xFFFFFB3F);      // 11. Next SEND_DATA will only include EOF
+      clearIRQStatus(0x000FFFFF);                                  // 14. Clear all IRQ_STATUS flags
+      sendData(inventory, 0, 0);                                   // 12. 13. 15. Idle/StopCom Command, Transceive Command, Send EOF
+    }
+  }
+  setRF_off();                                                     // 16. Switch off RF field
+  setupRF();                                                       // 1. 2. Load ISO15693 config, RF on
+  return ISO15693_EC_OK;
+}
+
+/*
  * Read single block, code=20
  *
  * Request format: SOF, Req.Flags, ReadSingleBlock, UID (opt.), BlockNumber, CRC16, EOF

--- a/PN5180ISO15693.cpp
+++ b/PN5180ISO15693.cpp
@@ -78,12 +78,12 @@ ISO15693ErrorCode PN5180ISO15693::getInventory(uint8_t *uid) {
  */
 ISO15693ErrorCode PN5180ISO15693::getInventoryMultiple(uint8_t *uid, uint8_t maxTags, uint8_t *numCard) {
   ESP_LOGD(TAG,"getInventory: Get Inventory...");
-  uint8_t collision[maxTags];
+  uint16_t collision[maxTags];
   *numCard = 0;
   uint8_t numCol = 0;
   inventoryPoll(uid, maxTags, numCard, &numCol, collision);
   PN5180DEBUG("Number of collisions=");
-  PN5180DEBUG(numCol)
+  PN5180DEBUG(numCol);
   PN5180DEBUG("\n");
 
   while(numCol){                                                 // 5+ Continue until no collisions detected
@@ -99,7 +99,7 @@ ISO15693ErrorCode PN5180ISO15693::getInventoryMultiple(uint8_t *uid, uint8_t max
   return ISO15693_EC_OK;
 }
 
-ISO15693ErrorCode PN5180ISO15693::inventoryPoll(uint8_t *uid, uint8_t maxTags, uint8_t *numCard, uint8_t *numCol, uint8_t *collision){
+ISO15693ErrorCode PN5180ISO15693::inventoryPoll(uint8_t *uid, uint8_t maxTags, uint8_t *numCard, uint8_t *numCol, uint16_t *collision){
   uint8_t maskLen = 0;
   if(*numCol > 0){
     uint32_t mask = collision[0];
@@ -108,59 +108,72 @@ ISO15693ErrorCode PN5180ISO15693::inventoryPoll(uint8_t *uid, uint8_t maxTags, u
       maskLen++;
     }while(mask > 0);
   } 
-  uint8_t *readBuffer;
-  uint8_t *p = &collision[0];
+  uint8_t *p = (uint8_t*)&(collision[0]);
   //                      Flags,  CMD,
   uint8_t inventory[7] = { 0x06, 0x01, maskLen*4, p[0], p[1], p[2], p[3] };
   //                         |\- inventory flag + high data rate
   //                         \-- 16 slots: upto 16 cards, no AFI field present
   uint8_t cmdLen = 3 + (maskLen/2) + (maskLen%2);
 #ifdef DEBUG
-  printf("mask=%d, maskLen=%d, cmdLen=%d\n", collision[0], maskLen, cmdLen);
+  printf("inventoryPoll inputs: maxTags=%d, numCard=%d, numCol=%d\n", maxTags, *numCard, *numCol);
+  printf("mask=%d, maskLen=%d, cmdLen=%d\n", p[0], maskLen, cmdLen);
 #endif
-  clearIRQStatus(0x000FFFFF);                                  // 3. Clear all IRQ_STATUS flags
-  sendData(inventory, cmdLen, 0);                              // 4. 5. 6. Idle/StopCom Command, Transceive Command, Inventory command
+  clearIRQStatus(0x000FFFFF);                                      // 3. Clear all IRQ_STATUS flags
+  sendData(inventory, cmdLen, 0);                                  // 4. 5. 6. Idle/StopCom Command, Transceive Command, Inventory command
   
-  for(int slot=0; slot<16; slot++){                                   // 7. Loop to check 16 time slots for data
+  for(int slot=0; slot<16; slot++){                                // 7. Loop to check 16 time slots for data
     uint32_t rxStatus;
     uint32_t irqStatus = getIRQStatus();
     readRegister(RX_STATUS, &rxStatus);
     uint16_t len = (uint16_t)(rxStatus & 0x000001ff);
-    if((rxStatus >> 18) & 0x01 && *numCol < maxTags){                  // 7+ Determine if a collision occurred
-      if(maskLen > 0) collision[*numCol++] = collision[0] | (slot << (maskLen * 2));
-      else collision[*numCol++] = slot << (maskLen * 2);     // Yes, store position of collision
+    if((rxStatus >> 18) & 0x01 && *numCol < maxTags){              // 7+ Determine if a collision occurred
+      if(maskLen > 0) collision[*numCol] = collision[0] | (slot << (maskLen * 2));
+      else collision[*numCol] = slot << (maskLen * 2); // Yes, store position of collision
+      *numCol = *numCol + 1;
 #ifdef DEBUG
       printf("Collision detected for UIDs matching %X starting at LSB", collision[*numCol-1]);
 #endif
     }
-    else if(!(irqStatus & RX_IRQ_STAT) && !len){               // 8. Check if a card has responded
+    else if(!(irqStatus & RX_IRQ_STAT) && !len){                   // 8. Check if a card has responded
       PN5180DEBUG("getInventoryMultiple: No card in this time slot. State=");
       PN5180DEBUG(irqStatus);
       PN5180DEBUG("\n");
     }
     else{
 #ifdef DEBUG
-      printf("slot=%d, irqStatus: %ld, RX_STATUS: %ld, Response length=%d", slot, irqStatus, rxStatus, len);
+      printf("slot=%d, irqStatus: %ld, RX_STATUS: %ld, Response length=%d\n", slot, irqStatus, rxStatus, len);
 #endif
-      readBuffer = readData(len);                              // 9. Read reception buffer
+      uint8_t *readBuffer;
+      readBuffer = readData(len+1);                                // 9. Read reception buffer
+#ifdef DEBUG
+      printf("readBuffer= ");
+      for(int i=0; i<len+1; i++){
+        if(readBuffer[i]<16) printf("0");
+        printf("%X", readBuffer[i]);
+        printf(":");
+      }
+      printf("\n");
+#endif
       if(0L == readBuffer){
         PN5180DEBUG("getInventoryMultiple: ERROR in readData!");
         return ISO15693_EC_UNKNOWN_ERROR;
       }
 
-      // Record raw UID data                                          // 10. Record all data to Inventory struct
+      // Record raw UID data                                       // 10. Record all data to Inventory struct
       for (int i=0; i<8; i++) {
-        uid[*numCard*8 + i] = readBuffer[2+i];
+        uint8_t startAddr = (*numCard * 8) + i;
+        uid[startAddr] = readBuffer[2+i];
       }
+      *numCard = *numCard + 1;
 
 #ifdef DEBUG
-      printf("getInventory: Response flags: 0x%X, Data Storage Format ID: 0x%X\n", readBuffer[0], readBuffer[1]);
+      printf("getInventoryMultiple: Response flags: 0x%X, Data Storage Format ID: 0x%X\n", readBuffer[0], readBuffer[1]);
+      printf("numCard=%d\n", *numCard);
 #endif
-      *numCard++;
     }
     
     if(slot+1 < 16){ // If we have more cards to poll for...
-      writeRegisterWithAndMask(TX_CONFIG, 0xFFFFFB3F);      // 11. Next SEND_DATA will only include EOF
+      writeRegisterWithAndMask(TX_CONFIG, 0xFFFFFB3F);             // 11. Next SEND_DATA will only include EOF
       clearIRQStatus(0x000FFFFF);                                  // 14. Clear all IRQ_STATUS flags
       sendData(inventory, 0, 0);                                   // 12. 13. 15. Idle/StopCom Command, Transceive Command, Send EOF
     }
@@ -323,6 +336,93 @@ ISO15693ErrorCode PN5180ISO15693::writeSingleBlock(uint8_t *uid, uint8_t blockNo
 }
 
 /*
+ * Read multiple block, code=23
+ *
+ * Request format: SOF, Req.Flags, ReadMultipleBlock, UID (opt.), FirstBlockNumber, numBlocks, CRC16, EOF
+ * Response format:
+ *  when ERROR flag is set:
+ *    SOF, Resp.Flags, ErrorCode, CRC16, EOF
+ *
+ *     Response Flags:
+  *    xxxx.3xx0
+  *         |||\_ Error flag: 0=no error, 1=error detected, see error field
+  *         \____ Extension flag: 0=no extension, 1=protocol format is extended
+  *
+  *  If Error flag is set, the following error codes are defined:
+  *    01 = The command is not supported, i.e. the request code is not recognized.
+  *    02 = The command is not recognized, i.e. a format error occurred.
+  *    03 = The option is not supported.
+  *    0F = Unknown error.
+  *    10 = The specific block is not available.
+  *    11 = The specific block is already locked and cannot be locked again.
+  *    12 = The specific block is locked and cannot be changed.
+  *    13 = The specific block was not successfully programmed.
+  *    14 = The specific block was not successfully locked.
+  *    A0-DF = Custom command error codes
+ *
+ *  when ERROR flag is NOT set:
+ *    SOF, Flags, BlockData (len=blockSize * numBlock), CRC16, EOF
+ */
+ISO15693ErrorCode PN5180ISO15693::readMultipleBlock(uint8_t *uid, uint8_t blockNo, uint8_t numBlock, uint8_t *blockData, uint8_t blockSize) {
+  if(blockNo > numBlock-1){ // Attempted to start at a block greater than the num blocks on the VICC
+    PN5180DEBUG("Starting block exceeds length of data");
+    return ISO15693_EC_BLOCK_NOT_AVAILABLE;
+  }
+  if( (blockNo + numBlock) > numBlock ){ // Will attempt to read a block greater than the num blocks on the VICC 
+    PN5180DEBUG("End of block exceeds length of data");
+    return ISO15693_EC_BLOCK_NOT_AVAILABLE;
+  }
+  
+  //                              flags, cmd, uid,             1stBlock blocksToRead  
+  uint8_t readMultipleCmd[12] = { 0x22, 0x23, 1,2,3,4,5,6,7,8, blockNo, numBlock-1 }; // UID has LSB first!
+  //                                |\- high data rate
+  //                                \-- no options, addressed by UID
+  
+  for (int i=0; i<8; i++) {
+    readMultipleCmd[2+i] = uid[i];
+  }
+
+  PN5180DEBUG("readMultipleBlock: Read Block #");
+  PN5180DEBUG(blockNo);
+  PN5180DEBUG("-");
+  PN5180DEBUG(blockNo+numBlock-1);
+  PN5180DEBUG(", blockSize=");
+  PN5180DEBUG(blockSize);
+  PN5180DEBUG(", Cmd: ");
+  for (int i=0; i<sizeof(readMultipleCmd); i++) {
+    PN5180DEBUG(" ");
+    PN5180DEBUG(formatHex(readMultipleCmd[i]));
+  }
+
+  uint8_t *resultPtr;
+  ISO15693ErrorCode rc = issueISO15693Command(readMultipleCmd, sizeof(readMultipleCmd), &resultPtr);
+  if (ISO15693_EC_OK != rc) return rc;
+
+  PN5180DEBUG("readMultipleBlock: Value=");
+  for (int i=0; i<numBlock * blockSize; i++) {
+    blockData[i] = resultPtr[1+i];
+#ifdef DEBUG    
+    PN5180DEBUG(formatHex(blockData[i]));
+    PN5180DEBUG(" ");
+#endif 
+  }
+
+#ifdef DEBUG
+  PN5180DEBUG(" ");
+  for (int i=0; i<blockSize; i++) {
+    char c = blockData[i];
+    if (isPrintable(c)) {
+      PN5180DEBUG(c);
+    }
+    else PN5180DEBUG(".");
+  }
+  PN5180DEBUG("\n");
+#endif
+
+  return ISO15693_EC_OK;
+}
+
+/*
  * Get System Information, code=2B
  *
  * Request format: SOF, Req.Flags, GetSysInfo, UID (opt.), CRC16, EOF
@@ -406,8 +506,9 @@ ISO15693ErrorCode PN5180ISO15693::getSystemInfo(uint8_t *uid, uint8_t *blockSize
 
   uint8_t infoFlags = readBuffer[1];
   if (infoFlags & 0x01) { // DSFID flag
+    uint8_t dsfid = *p++;
     PN5180DEBUG("DSFID=");  // Data storage format identifier
-    PN5180DEBUG(formatHex(uint8_t(*p++)));
+    PN5180DEBUG(formatHex(dsfid));
     PN5180DEBUG("\n");
   }
 #ifdef DEBUG
@@ -462,8 +563,9 @@ ISO15693ErrorCode PN5180ISO15693::getSystemInfo(uint8_t *uid, uint8_t *blockSize
 #endif
    
   if (infoFlags & 0x08) { // IC reference
+    uint8_t iRef = *p++;
     PN5180DEBUG("IC Ref=");
-    PN5180DEBUG(formatHex(uint8_t(*p++)));
+    PN5180DEBUG(formatHex(iRef));
     PN5180DEBUG("\n");
   }
 #ifdef DEBUG
@@ -621,14 +723,17 @@ ISO15693ErrorCode PN5180ISO15693::issueISO15693Command(uint8_t *cmd, uint8_t cmd
 
   uint32_t irqR = getIRQStatus();
   if (0 == (irqR & RX_SOF_DET_IRQ_STAT)) {
-	return EC_NO_CARD;
+    PN5180DEBUG("Didnt detect RX_SOF_DET_IRQ_STAT after sendData");
+	  return EC_NO_CARD;
   }
   
   unsigned long startedWaiting = millis();
   while(!(irqR & RX_IRQ_STAT)) {
-	if (millis() - startedWaiting > commandTimeout) {
-		return EC_NO_CARD;
-	}
+    irqR = getIRQStatus();
+    if (millis() - startedWaiting > commandTimeout) {
+      PN5180DEBUG("Didnt detect RX_IRQ_STAT after sendData");
+      return EC_NO_CARD;
+    }
   }
   
   uint32_t rxStatus;
@@ -660,8 +765,9 @@ ISO15693ErrorCode PN5180ISO15693::issueISO15693Command(uint8_t *cmd, uint8_t cmd
 
   uint32_t irqStatus = getIRQStatus();
   if (0 == (RX_SOF_DET_IRQ_STAT & irqStatus)) { // no card detected
-     clearIRQStatus(TX_IRQ_STAT | IDLE_IRQ_STAT);
-     return EC_NO_CARD;
+    PN5180DEBUG("Didnt detect RX_SOF_DET_IRQ_STAT after readData");
+    clearIRQStatus(TX_IRQ_STAT | IDLE_IRQ_STAT);
+    return EC_NO_CARD;
   }
 
   uint8_t responseFlags = (*resultPtr)[0];
@@ -671,7 +777,7 @@ ISO15693ErrorCode PN5180ISO15693::issueISO15693Command(uint8_t *cmd, uint8_t cmd
     PN5180DEBUG("ERROR code=");
     PN5180DEBUG(formatHex(errorCode));
     PN5180DEBUG(" - ");
-    PN5180DEBUG(strerror(errorCode));
+    PN5180DEBUG(strerror((ISO15693ErrorCode)errorCode));
     PN5180DEBUG("\n");
 
     if (errorCode >= 0xA0) { // custom command error codes

--- a/PN5180ISO15693.h
+++ b/PN5180ISO15693.h
@@ -43,13 +43,14 @@ public:
   
 private:
   ISO15693ErrorCode issueISO15693Command(uint8_t *cmd, uint8_t cmdLen, uint8_t **resultPtr);
-  ISO15693ErrorCode inventoryPoll(uint8_t *uid, uint8_t maxTags, uint8_t *numCard, uint8_t *numCol, uint8_t *collision);
+  ISO15693ErrorCode inventoryPoll(uint8_t *uid, uint8_t maxTags, uint8_t *numCard, uint8_t *numCol, uint16_t *collision);
 public:
   ISO15693ErrorCode getInventory(uint8_t *uid);
   ISO15693ErrorCode getInventoryMultiple(uint8_t *uid, uint8_t maxTags, uint8_t *numCard);
 
   ISO15693ErrorCode readSingleBlock(uint8_t *uid, uint8_t blockNo, uint8_t *blockData, uint8_t blockSize);
   ISO15693ErrorCode writeSingleBlock(uint8_t *uid, uint8_t blockNo, uint8_t *blockData, uint8_t blockSize);
+  ISO15693ErrorCode readMultipleBlock(uint8_t *uid, uint8_t blockNo, uint8_t numBlock, uint8_t *blockData, uint8_t blockSize);
 
   ISO15693ErrorCode getSystemInfo(uint8_t *uid, uint8_t *blockSize, uint8_t *numBlocks);
    

--- a/PN5180ISO15693.h
+++ b/PN5180ISO15693.h
@@ -43,8 +43,10 @@ public:
   
 private:
   ISO15693ErrorCode issueISO15693Command(uint8_t *cmd, uint8_t cmdLen, uint8_t **resultPtr);
+  ISO15693ErrorCode inventoryPoll(uint8_t *uid, uint8_t maxTags, uint8_t *numCard, uint8_t *numCol, uint8_t *collision);
 public:
   ISO15693ErrorCode getInventory(uint8_t *uid);
+  ISO15693ErrorCode getInventoryMultiple(uint8_t *uid, uint8_t maxTags, uint8_t *numCard);
 
   ISO15693ErrorCode readSingleBlock(uint8_t *uid, uint8_t blockNo, uint8_t *blockData, uint8_t blockSize);
   ISO15693ErrorCode writeSingleBlock(uint8_t *uid, uint8_t blockNo, uint8_t *blockData, uint8_t blockSize);

--- a/PN5180ISO15693.h
+++ b/PN5180ISO15693.h
@@ -48,6 +48,7 @@ public:
 
   ISO15693ErrorCode readSingleBlock(uint8_t *uid, uint8_t blockNo, uint8_t *blockData, uint8_t blockSize);
   ISO15693ErrorCode writeSingleBlock(uint8_t *uid, uint8_t blockNo, uint8_t *blockData, uint8_t blockSize);
+  ISO15693ErrorCode readMultipleBlock(uint8_t *uid, uint8_t blockNo, uint8_t numBlock, uint8_t *blockData, uint8_t blockSize);
 
   ISO15693ErrorCode getSystemInfo(uint8_t *uid, uint8_t *blockSize, uint8_t *numBlocks);
    

--- a/examples/PN5180-MultipleBlock/PN5180-MultipleBlock.ino
+++ b/examples/PN5180-MultipleBlock/PN5180-MultipleBlock.ino
@@ -1,0 +1,340 @@
+// NAME: PN5180-MultipleBlock.ino
+//
+// DESC: Example usage of the PN5180 Library for the PN5180-NFC Module
+//       from NXP Semiconductors. This example is similar to the 
+//       PN5180-Library example, but executes a single command (0x23)
+//       to read all block data from an ISO15693 card.
+//
+// Copyright (c) 2018 by Andreas Trappmann. All rights reserved.
+// Copyright (c) 2023 by Adam Billingsley.
+//
+// This file is part of the PN5180 library for the Arduino environment.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// BEWARE: SPI with an Arduino to a PN5180 module has to be at a level of 3.3V
+// use of logic-level converters from 5V->3.3V is absolutely necessary
+// on most Arduinos for all input pins of PN5180!
+// If used with an ESP-32, there is no need for a logic-level converter, since
+// it operates on 3.3V already.
+//
+// Arduino <-> Level Converter <-> PN5180 pin mapping:
+// 5V             <-->             5V
+// 3.3V           <-->             3.3V
+// GND            <-->             GND
+// 5V      <-> HV
+// GND     <-> GND (HV)
+//             LV              <-> 3.3V
+//             GND (LV)        <-> GND
+// SCLK,13 <-> HV1 - LV1       --> SCLK
+// MISO,12        <---         <-- MISO
+// MOSI,11 <-> HV3 - LV3       --> MOSI
+// SS,10   <-> HV4 - LV4       --> NSS (=Not SS -> active LOW)
+// BUSY,9         <---             BUSY
+// Reset,7 <-> HV2 - LV2       --> RST
+//
+// ESP-32    <--> PN5180 pin mapping:
+// 3.3V      <--> 3.3V
+// GND       <--> GND
+// SCLK, 18   --> SCLK
+// MISO, 19  <--  MISO
+// MOSI, 23   --> MOSI
+// SS, 16     --> NSS (=Not SS -> active LOW)
+// BUSY, 5   <--  BUSY
+// Reset, 17  --> RST
+//
+
+/*
+ * Pins on ICODE2 Reader Writer:
+ *
+ *   ICODE2   |     PN5180
+ * pin  label | pin  I/O  name
+ * 1    +5V
+ * 2    +3,3V
+ * 3    RST     10   I    RESET_N (low active)
+ * 4    NSS     1    I    SPI NSS
+ * 5    MOSI    3    I    SPI MOSI
+ * 6    MISO    5    O    SPI MISO
+ * 7    SCK     7    I    SPI Clock
+ * 8    BUSY    8    O    Busy Signal
+ * 9    GND     9  Supply VSS - Ground
+ * 10   GPIO    38   O    GPO1 - Control for external DC/DC
+ * 11   IRQ     39   O    IRQ
+ * 12   AUX     40   O    AUX1 - Analog/Digital test signal
+ * 13   REQ     2?  I/O   AUX2 - Analog test bus or download
+ *
+ */
+
+//#define WRITE_ENABLED 1
+
+#include <PN5180.h>
+#include <PN5180ISO15693.h>
+
+#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_MEGA2560) || defined(ARDUINO_AVR_NANO)
+
+#define PN5180_NSS  10
+#define PN5180_BUSY 9
+#define PN5180_RST  7
+
+#elif defined(ARDUINO_ARCH_ESP32)
+
+#define PN5180_NSS  16
+#define PN5180_BUSY 5
+#define PN5180_RST  17
+
+#else
+#error Please define your pinout here!
+#endif
+
+PN5180ISO15693 nfc(PN5180_NSS, PN5180_BUSY, PN5180_RST);
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println(F("=================================="));
+  Serial.println(F("Uploaded: " __DATE__ " " __TIME__));
+  Serial.println(F("PN5180 ISO15693 Demo Sketch"));
+
+  nfc.begin();
+
+  Serial.println(F("----------------------------------"));
+  Serial.println(F("PN5180 Hard-Reset..."));
+  nfc.reset();
+
+  Serial.println(F("----------------------------------"));
+  Serial.println(F("Reading product version..."));
+  uint8_t productVersion[2];
+  nfc.readEEprom(PRODUCT_VERSION, productVersion, sizeof(productVersion));
+  Serial.print(F("Product version="));
+  Serial.print(productVersion[1]);
+  Serial.print(".");
+  Serial.println(productVersion[0]);
+
+  if (0xff == productVersion[1]) { // if product version 255, the initialization failed
+    Serial.println(F("Initialization failed!?"));
+    Serial.println(F("Press reset to restart..."));
+    Serial.flush();
+    exit(-1); // halt
+  }
+  
+  Serial.println(F("----------------------------------"));
+  Serial.println(F("Reading firmware version..."));
+  uint8_t firmwareVersion[2];
+  nfc.readEEprom(FIRMWARE_VERSION, firmwareVersion, sizeof(firmwareVersion));
+  Serial.print(F("Firmware version="));
+  Serial.print(firmwareVersion[1]);
+  Serial.print(".");
+  Serial.println(firmwareVersion[0]);
+
+  Serial.println(F("----------------------------------"));
+  Serial.println(F("Reading EEPROM version..."));
+  uint8_t eepromVersion[2];
+  nfc.readEEprom(EEPROM_VERSION, eepromVersion, sizeof(eepromVersion));
+  Serial.print(F("EEPROM version="));
+  Serial.print(eepromVersion[1]);
+  Serial.print(".");
+  Serial.println(eepromVersion[0]);
+
+  /*
+  Serial.println(F("----------------------------------"));
+  Serial.println(F("Reading IRQ pin config..."));
+  uint8_t irqConfig;
+  nfc.readEEprom(IRQ_PIN_CONFIG, &irqConfig, 1));
+  Serial.print(F("IRQ_PIN_CONFIG=0x"));
+  Serial.println(irqConfig, HEX);
+
+  Serial.println(F("----------------------------------"));
+  Serial.println(F("Reading IRQ_ENABLE register..."));
+  uint32_t irqEnable;
+  nfc.readRegister(IRQ_ENABLE, &irqEnable));
+  Serial.print(F("IRQ_ENABLE=0x"));
+  Serial.println(irqConfig, HEX);
+  */
+
+  Serial.println(F("----------------------------------"));
+  Serial.println(F("Enable RF field..."));
+  nfc.setupRF();
+}
+
+uint32_t loopCnt = 0;
+bool errorFlag = false;
+
+//SLIX2 Passwords, first is manufacture standard
+uint8_t standardpassword[] = {0x0F, 0x0F, 0x0F, 0x0F};
+//New Password
+uint8_t password[] = {0x12, 0x34, 0x56, 0x78};
+
+void loop() {
+  if (errorFlag) {
+    uint32_t irqStatus = nfc.getIRQStatus();
+    showIRQStatus(irqStatus);
+
+    if (0 == (RX_SOF_DET_IRQ_STAT & irqStatus)) { // no card detected
+      Serial.println(F("*** No card detected!"));
+    }
+
+    nfc.reset();
+    nfc.setupRF();
+
+    errorFlag = false;
+  }
+
+  Serial.println(F("----------------------------------"));
+  Serial.print(F("Loop #"));
+  Serial.println(loopCnt++);
+
+/*
+  // code for unlocking an ICODE SLIX2 protected tag   
+  ISO15693ErrorCode myrc = nfc.unlockICODESLIX2(password);
+  if (ISO15693_EC_OK == myrc) {
+    Serial.println("unlockICODESLIX2 successful");
+  }
+*/
+  
+/* 
+  // code for set a new SLIX2 privacy password
+  nfc.getInventory(uid);
+  Serial.println("set new password"); 
+  
+  ISO15693ErrorCode myrc2 = nfc.newpasswordICODESLIX2(password, standardpassword, uid);
+  if (ISO15693_EC_OK == myrc2) { 
+   Serial.println("sucess! new password set");    
+  }else{
+   Serial.println("fail! no new password set: "); 
+   Serial.println(nfc.strerror(myrc2));  
+   Serial.println(" "); 
+  } 
+ */
+  
+  uint8_t uid[8];
+  ISO15693ErrorCode rc = nfc.getInventory(uid);
+  if (ISO15693_EC_OK != rc) {
+    Serial.print(F("Error in getInventory: "));
+    Serial.println(nfc.strerror(rc));
+    errorFlag = true;
+    return;
+  }
+  Serial.print(F("Inventory successful, UID="));
+  for (int i=0; i<8; i++) {
+    Serial.print(uid[7-i], HEX); // LSB is first
+    if (i < 2) Serial.print(":");
+  }
+  Serial.println();
+
+  Serial.println(F("----------------------------------"));
+  uint8_t blockSize, numBlocks;
+  rc = nfc.getSystemInfo(uid, &blockSize, &numBlocks);
+  if (ISO15693_EC_OK != rc) {
+    Serial.print(F("Error in getSystemInfo: "));
+    Serial.println(nfc.strerror(rc));
+    errorFlag = true;
+    return;
+  }
+  Serial.print(F("System Info retrieved: blockSize="));
+  Serial.print(blockSize);
+  Serial.print(F(", numBlocks="));
+  Serial.println(numBlocks);
+
+  Serial.println(F("----------------------------------"));
+  uint8_t readBuffer[numBlocks*blockSize];
+  
+  rc = nfc.readMultipleBlock(uid, 0, numBlocks, readBuffer, blockSize);
+  if (ISO15693_EC_OK != rc) {
+    Serial.print(F("Error in readMultipleBlock #"));
+    Serial.print("0-");
+    Serial.print(numBlocks-1);
+    Serial.print(": ");
+    Serial.println(nfc.strerror(rc));
+    errorFlag = true;
+    return;
+  }
+  Serial.print(F("Read blocks #0-"));
+  Serial.print(numBlocks-1);
+  Serial.println(":");
+  for(int i=0; i<numBlocks; i++){
+    if(i < 10) Serial.print(" ");
+    Serial.print("#");
+    Serial.print(i);
+    Serial.print(": ");
+    uint16_t startAddr = i * blockSize;
+    for (int j=0; j<blockSize; j++) {
+      if (readBuffer[startAddr + j] < 16) Serial.print("0");
+      Serial.print(readBuffer[startAddr + j], HEX);
+      Serial.print(" ");
+    }
+    Serial.print(" ");
+    for (int j=0; j<blockSize; j++) {
+      if (isprint(readBuffer[startAddr + j])) {
+        Serial.print((char)readBuffer[startAddr + j]);
+      }
+      else Serial.print(".");
+    }
+    Serial.println();
+  }
+
+#ifdef WRITE_ENABLED
+  Serial.println(F("----------------------------------"));
+  uint8_t *writeBuffer = malloc(blockSize);
+  for (int i=0; i<blockSize; i++) {
+    writeBuffer[i] = 0x80 + i;
+  }
+  for (int no=0; no<numBlocks; no++) {
+    rc = nfc.writeSingleBlock(uid, no, writeBuffer, blockSize);
+    if (ISO15693_EC_OK == rc) {
+      Serial.print(F("Wrote block #"));
+      Serial.println(no);
+    }
+    else {
+      Serial.print(F("Error in writeSingleBlock #"));
+      Serial.print(no);
+      Serial.print(": ");
+      Serial.println(nfc.strerror(rc));
+      errorFlag = true;
+      return;
+    }
+  }
+#endif /* WRITE_ENABLED */
+
+/*
+  // code for locking an ICODE SLIX2 protected tag   
+  ISO15693ErrorCode myrc = nfc.lockICODESLIX2(password);
+  if (ISO15693_EC_OK == myrc) {
+    Serial.println("lockICODESLIX2 successful");
+    delay(5000);
+*/
+  delay(1000);
+}
+
+void showIRQStatus(uint32_t irqStatus) {
+  Serial.print(F("IRQ-Status 0x"));
+  Serial.print(irqStatus, HEX);
+  Serial.print(": [ ");
+  if (irqStatus & (1<< 0)) Serial.print(F("RQ "));
+  if (irqStatus & (1<< 1)) Serial.print(F("TX "));
+  if (irqStatus & (1<< 2)) Serial.print(F("IDLE "));
+  if (irqStatus & (1<< 3)) Serial.print(F("MODE_DETECTED "));
+  if (irqStatus & (1<< 4)) Serial.print(F("CARD_ACTIVATED "));
+  if (irqStatus & (1<< 5)) Serial.print(F("STATE_CHANGE "));
+  if (irqStatus & (1<< 6)) Serial.print(F("RFOFF_DET "));
+  if (irqStatus & (1<< 7)) Serial.print(F("RFON_DET "));
+  if (irqStatus & (1<< 8)) Serial.print(F("TX_RFOFF "));
+  if (irqStatus & (1<< 9)) Serial.print(F("TX_RFON "));
+  if (irqStatus & (1<<10)) Serial.print(F("RF_ACTIVE_ERROR "));
+  if (irqStatus & (1<<11)) Serial.print(F("TIMER0 "));
+  if (irqStatus & (1<<12)) Serial.print(F("TIMER1 "));
+  if (irqStatus & (1<<13)) Serial.print(F("TIMER2 "));
+  if (irqStatus & (1<<14)) Serial.print(F("RX_SOF_DET "));
+  if (irqStatus & (1<<15)) Serial.print(F("RX_SC_DET "));
+  if (irqStatus & (1<<16)) Serial.print(F("TEMPSENS_ERROR "));
+  if (irqStatus & (1<<17)) Serial.print(F("GENERAL_ERROR "));
+  if (irqStatus & (1<<18)) Serial.print(F("HV_ERROR "));
+  if (irqStatus & (1<<19)) Serial.print(F("LPCD "));
+  Serial.println("]");
+}

--- a/examples/PN5180-ReadMultipleUID/PN5180-ReadMultipleUID.ino
+++ b/examples/PN5180-ReadMultipleUID/PN5180-ReadMultipleUID.ino
@@ -208,7 +208,9 @@ void loop() {
       Serial.print(i);
       Serial.print("= ");
       for (int j=0; j<8; j++) {
-        Serial.print(uid[(i*8)+(7-j)], HEX); // LSB is first
+        uint8_t startAddr = (i*8) + 7 - j;
+        if(uid[startAddr] < 16) Serial.print("0");
+        Serial.print(uid[startAddr], HEX); // LSB is first
         if (j < 2) Serial.print(":");
       }
       Serial.println();

--- a/examples/PN5180-ReadMultipleUID/PN5180-ReadMultipleUID.ino
+++ b/examples/PN5180-ReadMultipleUID/PN5180-ReadMultipleUID.ino
@@ -1,0 +1,246 @@
+// NAME: PN5180-Library.ino
+//
+// DESC: Example usage of the PN5180 library for the PN5180-NFC Module
+//       from NXP Semiconductors.
+//
+// Copyright (c) 2018 by Andreas Trappmann. All rights reserved.
+//
+// This file is part of the PN5180 library for the Arduino environment.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// BEWARE: SPI with an Arduino to a PN5180 module has to be at a level of 3.3V
+// use of logic-level converters from 5V->3.3V is absolutely necessary
+// on most Arduinos for all input pins of PN5180!
+// If used with an ESP-32, there is no need for a logic-level converter, since
+// it operates on 3.3V already.
+//
+// Arduino <-> Level Converter <-> PN5180 pin mapping:
+// 5V             <-->             5V
+// 3.3V           <-->             3.3V
+// GND            <-->             GND
+// 5V      <-> HV
+// GND     <-> GND (HV)
+//             LV              <-> 3.3V
+//             GND (LV)        <-> GND
+// SCLK,13 <-> HV1 - LV1       --> SCLK
+// MISO,12        <---         <-- MISO
+// MOSI,11 <-> HV3 - LV3       --> MOSI
+// SS,10   <-> HV4 - LV4       --> NSS (=Not SS -> active LOW)
+// BUSY,9         <---             BUSY
+// Reset,7 <-> HV2 - LV2       --> RST
+//
+// ESP-32    <--> PN5180 pin mapping:
+// 3.3V      <--> 3.3V
+// GND       <--> GND
+// SCLK, 18   --> SCLK
+// MISO, 19  <--  MISO
+// MOSI, 23   --> MOSI
+// SS, 16     --> NSS (=Not SS -> active LOW)
+// BUSY, 5   <--  BUSY
+// Reset, 17  --> RST
+//
+
+/*
+ * Pins on ICODE2 Reader Writer:
+ *
+ *   ICODE2   |     PN5180
+ * pin  label | pin  I/O  name
+ * 1    +5V
+ * 2    +3,3V
+ * 3    RST     10   I    RESET_N (low active)
+ * 4    NSS     1    I    SPI NSS
+ * 5    MOSI    3    I    SPI MOSI
+ * 6    MISO    5    O    SPI MISO
+ * 7    SCK     7    I    SPI Clock
+ * 8    BUSY    8    O    Busy Signal
+ * 9    GND     9  Supply VSS - Ground
+ * 10   GPIO    38   O    GPO1 - Control for external DC/DC
+ * 11   IRQ     39   O    IRQ
+ * 12   AUX     40   O    AUX1 - Analog/Digital test signal
+ * 13   REQ     2?  I/O   AUX2 - Analog test bus or download
+ *
+ */
+
+//#define WRITE_ENABLED 1
+
+#include <PN5180.h>
+#include <PN5180ISO15693.h>
+
+#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_MEGA2560) || defined(ARDUINO_AVR_NANO)
+
+#define PN5180_NSS  10
+#define PN5180_BUSY 9
+#define PN5180_RST  7
+
+#elif defined(ARDUINO_ARCH_ESP32)
+
+#define PN5180_NSS  16
+#define PN5180_BUSY 5
+#define PN5180_RST  17
+
+#else
+#error Please define your pinout here!
+#endif
+
+PN5180ISO15693 nfc(PN5180_NSS, PN5180_BUSY, PN5180_RST);
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println(F("=================================="));
+  Serial.println(F("Uploaded: " __DATE__ " " __TIME__));
+  Serial.println(F("PN5180 ISO15693 Demo Sketch"));
+
+  nfc.begin();
+
+  Serial.println(F("----------------------------------"));
+  Serial.println(F("PN5180 Hard-Reset..."));
+  nfc.reset();
+
+  Serial.println(F("----------------------------------"));
+  Serial.println(F("Reading product version..."));
+  uint8_t productVersion[2];
+  nfc.readEEprom(PRODUCT_VERSION, productVersion, sizeof(productVersion));
+  Serial.print(F("Product version="));
+  Serial.print(productVersion[1]);
+  Serial.print(".");
+  Serial.println(productVersion[0]);
+
+  if (0xff == productVersion[1]) { // if product version 255, the initialization failed
+    Serial.println(F("Initialization failed!?"));
+    Serial.println(F("Press reset to restart..."));
+    Serial.flush();
+    exit(-1); // halt
+  }
+  
+  Serial.println(F("----------------------------------"));
+  Serial.println(F("Reading firmware version..."));
+  uint8_t firmwareVersion[2];
+  nfc.readEEprom(FIRMWARE_VERSION, firmwareVersion, sizeof(firmwareVersion));
+  Serial.print(F("Firmware version="));
+  Serial.print(firmwareVersion[1]);
+  Serial.print(".");
+  Serial.println(firmwareVersion[0]);
+
+  Serial.println(F("----------------------------------"));
+  Serial.println(F("Reading EEPROM version..."));
+  uint8_t eepromVersion[2];
+  nfc.readEEprom(EEPROM_VERSION, eepromVersion, sizeof(eepromVersion));
+  Serial.print(F("EEPROM version="));
+  Serial.print(eepromVersion[1]);
+  Serial.print(".");
+  Serial.println(eepromVersion[0]);
+
+  /*
+  Serial.println(F("----------------------------------"));
+  Serial.println(F("Reading IRQ pin config..."));
+  uint8_t irqConfig;
+  nfc.readEEprom(IRQ_PIN_CONFIG, &irqConfig, 1));
+  Serial.print(F("IRQ_PIN_CONFIG=0x"));
+  Serial.println(irqConfig, HEX);
+
+  Serial.println(F("----------------------------------"));
+  Serial.println(F("Reading IRQ_ENABLE register..."));
+  uint32_t irqEnable;
+  nfc.readRegister(IRQ_ENABLE, &irqEnable));
+  Serial.print(F("IRQ_ENABLE=0x"));
+  Serial.println(irqConfig, HEX);
+  */
+
+  Serial.println(F("----------------------------------"));
+  Serial.println(F("Enable RF field..."));
+  nfc.setupRF();
+}
+
+uint32_t loopCnt = 0;
+uint8_t numCard = 1;
+const uint8_t maxTags = 16;
+bool errorFlag = false;
+
+//SLIX2 Passwords, first is manufacture standard
+uint8_t standardpassword[] = {0x0F, 0x0F, 0x0F, 0x0F};
+//New Password
+uint8_t password[] = {0x12, 0x34, 0x56, 0x78};
+
+void loop() {
+  if (errorFlag) {
+    uint32_t irqStatus = nfc.getIRQStatus();
+    showIRQStatus(irqStatus);
+
+    if (0 == (RX_SOF_DET_IRQ_STAT & irqStatus)) { // no card detected
+      Serial.println(F("*** No card detected!"));
+    }
+
+    nfc.reset();
+    nfc.setupRF();
+
+    errorFlag = false;
+  }
+
+  // Multiple inventory
+  Serial.println(F("----------------------------------"));
+  Serial.print(F("Loop #"));
+  Serial.println(loopCnt++);
+  uint8_t uid[8*maxTags];
+  ISO15693ErrorCode rc = nfc.getInventoryMultiple(uid, maxTags, &numCard);
+  if (ISO15693_EC_OK != rc) {
+    Serial.print(F("Error in getInventory: "));
+    Serial.println(nfc.strerror(rc));
+    errorFlag = true;
+  }
+  else if(!numCard){
+    Serial.println("No cards detected.");
+  }
+  else{
+    Serial.print("Inventory successful. Discovered ");
+    Serial.print(numCard);
+    Serial.println(" cards.");
+    for(int i=0; i<numCard; i++){
+      Serial.print("UID #");
+      Serial.print(i);
+      Serial.print("= ");
+      for (int j=0; j<8; j++) {
+        Serial.print(uid[(i*8)+(7-j)], HEX); // LSB is first
+        if (j < 2) Serial.print(":");
+      }
+      Serial.println();
+    }
+  }
+  Serial.println(F("----------------------------------"));
+  delay(1000);
+}
+
+void showIRQStatus(uint32_t irqStatus) {
+  Serial.print(F("IRQ-Status 0x"));
+  Serial.print(irqStatus, HEX);
+  Serial.print(": [ ");
+  if (irqStatus & (1<< 0)) Serial.print(F("RQ "));
+  if (irqStatus & (1<< 1)) Serial.print(F("TX "));
+  if (irqStatus & (1<< 2)) Serial.print(F("IDLE "));
+  if (irqStatus & (1<< 3)) Serial.print(F("MODE_DETECTED "));
+  if (irqStatus & (1<< 4)) Serial.print(F("CARD_ACTIVATED "));
+  if (irqStatus & (1<< 5)) Serial.print(F("STATE_CHANGE "));
+  if (irqStatus & (1<< 6)) Serial.print(F("RFOFF_DET "));
+  if (irqStatus & (1<< 7)) Serial.print(F("RFON_DET "));
+  if (irqStatus & (1<< 8)) Serial.print(F("TX_RFOFF "));
+  if (irqStatus & (1<< 9)) Serial.print(F("TX_RFON "));
+  if (irqStatus & (1<<10)) Serial.print(F("RF_ACTIVE_ERROR "));
+  if (irqStatus & (1<<11)) Serial.print(F("TIMER0 "));
+  if (irqStatus & (1<<12)) Serial.print(F("TIMER1 "));
+  if (irqStatus & (1<<13)) Serial.print(F("TIMER2 "));
+  if (irqStatus & (1<<14)) Serial.print(F("RX_SOF_DET "));
+  if (irqStatus & (1<<15)) Serial.print(F("RX_SC_DET "));
+  if (irqStatus & (1<<16)) Serial.print(F("TEMPSENS_ERROR "));
+  if (irqStatus & (1<<17)) Serial.print(F("GENERAL_ERROR "));
+  if (irqStatus & (1<<18)) Serial.print(F("HV_ERROR "));
+  if (irqStatus & (1<<19)) Serial.print(F("LPCD "));
+  Serial.println("]");
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -28,6 +28,7 @@ transceiveCommand	KEYWORD2
 issueISO15693Command		KEYWORD2
 getInventory		KEYWORD2
 getInventoryMultiple		KEYWORD2
+getInventoryPoll		KEYWORD2
 readSingleBlock		KEYWORD2
 writeSingleBlock		KEYWORD2
 readMultipleBlock		KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -27,8 +27,10 @@ transceiveCommand	KEYWORD2
 
 issueISO15693Command		KEYWORD2
 getInventory		KEYWORD2
+getInventoryMultiple		KEYWORD2
 readSingleBlock		KEYWORD2
 writeSingleBlock		KEYWORD2
+readMultipleBlock		KEYWORD2
 getSystemInfo		KEYWORD2
 setupRF		KEYWORD2
 


### PR DESCRIPTION
Bugs:

- In getSystemInfo(), when parsing infoFlags, the pointer to the DSFID byte and IC Ref byte were only advanced when the DEBUG flag was defined. This caused incorrect numBlocks and blockSize to be pulled if not debugging.

- In issueISO15693Command(), after executing sendData, a loop with a timeout is used to detect RX_IRQ_STAT from the IRQ_STATUS register. However, if this loop is ever executed it will always return false since the variable containing the register flags is never updated inside the loop. The variable containing the register flags is now updated inside the loop.

- In issueISO15693Command(), if an error flag is raised in the response of readData, one of the return conditions returns a variable of type uint8_t named errorCode. However, the function type is ISO15693ErrorCode. Return value has been properly type casted.

Additions:

- readMultipleBlock() has been implemented. Per the ISO15693-3 standard, a command of 0x23 can be sent to read multiple blocks of data in a single request. This feature is supported by the PN5180 and this function properly implements this protocol. An additional example has been included demonstrating this feature. When multiple blocks of data are required, runtime is significantly shorter using this feature. Tested on ESP32 Devkit C with ISLIX NFC tags.