### PR TITLE
replace errno, which is often a macro

### DIFF
--- a/PN5180ISO15693.cpp
+++ b/PN5180ISO15693.cpp
@@ -817,12 +817,12 @@ bool PN5180ISO15693::setupRF() {
   return true;
 }
 
-const char *PN5180ISO15693::strerror(ISO15693ErrorCode errno) {
+const char *PN5180ISO15693::strerror(ISO15693ErrorCode code) {
   PN5180DEBUG(("ISO15693ErrorCode="));
-  PN5180DEBUG(errno);
+  PN5180DEBUG(code);
   PN5180DEBUG("\n");
   
-  switch (errno) {
+  switch (code) {
     case EC_NO_CARD: return ("No card detected!");
     case ISO15693_EC_OK: return ("OK!");
     case ISO15693_EC_NOT_SUPPORTED: return ("Command is not supported!");
@@ -835,7 +835,7 @@ const char *PN5180ISO15693::strerror(ISO15693ErrorCode errno) {
     case ISO15693_EC_BLOCK_NOT_PROGRAMMED: return ("Specified block was not successfully programmed!");
     case ISO15693_EC_BLOCK_NOT_LOCKED: return ("Specified block was not successfully locked!");
     default:
-      if ((errno >= 0xA0) && (errno <= 0xDF)) {
+      if ((code >= 0xA0) && (code <= 0xDF)) {
         return ("Custom command error code!");
       }
       else return ("Undefined error code in ISO15693!");

--- a/PN5180ISO15693.h
+++ b/PN5180ISO15693.h
@@ -66,7 +66,7 @@ public:
    */
 public:   
   bool setupRF();
-  const char *strerror(ISO15693ErrorCode errno);
+  const char *strerror(ISO15693ErrorCode code);
     
 };
 


### PR DESCRIPTION
When the variable was named `errno`, I would get compile errors like this attempting to use the `strerror` method (ESP32, platformio):

```
Compiling .pio/build/feather_nfc/lib2a7/EspSoftwareSerial/SoftwareSerial.cpp.o
src/feather_nfc_main.cpp: In function 'void loop()':
src/feather_nfc_main.cpp:22:78: error: no matching function for call to 'PN5180ISO15693::strerror(const ISO15693ErrorCode&)'
     Serial.printf("❌ Inventory error: %s\n", nfc_reader->strerror(inv_error));
                                                                              ^
In file included from src/feather_nfc_main.cpp:4:
.pio/libdeps/feather_nfc/PN5180 Library/PN5180ISO15693.h:65:30: note: candidate: 'const __FlashStringHelper* PN5180ISO15693::strerror(ISO15693ErrorCode* (*)())'
   const __FlashStringHelper *strerror(ISO15693ErrorCode errno);
                              ^~~~~~~~
.pio/libdeps/feather_nfc/PN5180 Library/PN5180ISO15693.h:65:30: note:   no known conversion for argument 1 from 'const ISO15693ErrorCode' to 'ISO15693ErrorCode* (*)()'
```

This fixes that by using a different variable name.