### PR TITLE
Debug fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/PN5180ISO15693.cpp
+++ b/PN5180ISO15693.cpp
@@ -506,9 +506,7 @@ ISO15693ErrorCode PN5180ISO15693::getSystemInfo(uint8_t *uid, uint8_t *blockSize
 
   uint8_t infoFlags = readBuffer[1];
   if (infoFlags & 0x01) { // DSFID flag
-#ifdef DEBUG
     uint8_t dsfid = *p++;
-#endif
     PN5180DEBUG("DSFID=");  // Data storage format identifier
     PN5180DEBUG(formatHex(dsfid));
     PN5180DEBUG("\n");
@@ -565,9 +563,7 @@ ISO15693ErrorCode PN5180ISO15693::getSystemInfo(uint8_t *uid, uint8_t *blockSize
 #endif
    
   if (infoFlags & 0x08) { // IC reference
-#ifdef DEBUG
     uint8_t iRef = *p++;
-#endif
     PN5180DEBUG("IC Ref=");
     PN5180DEBUG(formatHex(iRef));
     PN5180DEBUG("\n");


### PR DESCRIPTION
While working with ESP32-S3 Dev Module in Arduino IDE in Windows I found that enabling DEBUG was causing PN5180ISO15693::getSystemInfo() to not decode the buffer correctly which caused blockSize and numBlocks to be incorrect when using the NFC card supplied with a PN5180 dev kit I bought recently on Amazon.