### PR TITLE
Allow to change SPI frequency

### DIFF
--- a/PN5180.cpp
+++ b/PN5180.cpp
@@ -112,6 +112,11 @@ void PN5180::end() {
   PN5180DEBUG_EXIT;
 }
 
+// Update SPI Settings
+void PN5180::setSPISettingsFrecuency(uint32_t frecuency){
+  SPI_SETTINGS = SPISettings(frecuency, MSBFIRST, SPI_MODE0);
+}
+
 /*
  * WRITE_REGISTER - 0x00
  * This command is used to write a 32-bit value (little endian) to a configuration register.

--- a/PN5180.h
+++ b/PN5180.h
@@ -103,6 +103,7 @@ public:
 
   void begin(int8_t sck=-1, int8_t miso=-1, int8_t mosi=-1, int8_t SSpin=-1);
   void end();
+  void setSPISettingsFrecuency(uint32_t frecuency);
 
   /*
    * PN5180 direct commands with host interface


### PR DESCRIPTION
PR for SPI frequency refresh

Useful for longer cables or multiple SPI devices.


```cpp
//Lower frecuenty setup
PN5180ISO15693 nfc(NSS_PORT, BUSY_PORT, RST_PORT);
nfc.setSPISettingsFrecuency(1000000);
```